### PR TITLE
feat(timer): add StartButton component with styling and accessibility

### DIFF
--- a/src/components/TimerButton.test.tsx
+++ b/src/components/TimerButton.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import TimerButton from "./TimerButton";
+
+test("renders Start button to the screen", () => {
+  const handleClick = vi.fn();
+  render(<TimerButton toggleStart={handleClick} label="Start"/>);
+
+  const startButton = screen.getByRole('button', {name: /start/i});
+
+  expect(startButton).toBeInTheDocument();
+
+  fireEvent.click(startButton);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+
+  
+})

--- a/src/components/TimerButton.tsx
+++ b/src/components/TimerButton.tsx
@@ -1,0 +1,29 @@
+type StartButtonProps = {
+  toggleStart: () => void;
+  label: "Start" | "Pause" | "Resume";
+
+}
+
+export default function StartButton({toggleStart, label} : StartButtonProps) {
+
+  return (
+    <button 
+      type="button"
+      aria-pressed={label !== "Start"}
+      aria-label={`${label} the timer`}
+      onClick={toggleStart}
+      className="
+        w-full md:min-w-[120px] md:w-auto
+        px-6 py-3
+        text-white
+        border border-white rounded-lg 
+        bg-gray-400  hover:bg-gray-500 
+        hover:scale-105 focus:scale-105
+        focus:outline-none focus:ring-2 focus:ring-blue-400 
+        transition-transform duration-200"
+    >
+      {label}
+    </button>
+  )
+  
+}


### PR DESCRIPTION
## Summary
Add StartButton component with styling and accessibility

## Related Issue
Closes #4 (part of #1)

## Changes
- Added `StartButton` component with typed props:
  - `toggleStart: () => void`
  - `label: "Start" | "Pause" | "Resume"`
- Applied Tailwind styling:
  - Full width on small screens
  - Auto width with min width on medium+
  - Hover/focus scale and transition effects
- Added accessibility features:
  - `type="button"`
  - `aria-pressed` to indicate pressed state
  - Dynamic `aria-label` to match label


## Testing
- [x] Verified component renders without errors
- [x] Manually toggled label between states
- [x] Confirmed focus ring and hover states apply correctly
- [x] `npm test` passes locally

## QA Steps
1. Run app locally with `npm run dev`
2. Confirm Start button appears
3. Click button → confirm it toggles label
4. Use tab key to focus → confirm focus ring shows
5. Hover and click → confirm transitions apply smoothly

## Checklist
- [x] PR title uses Conventional Commits (`feat(timer): add StartButton component with styling and accessibility`)
- [x] Branch is up to date with `main`
- [x] No generated files committed