### PR TITLE
feat(button): add BaseButton component with semantic color variants and update Timer/Reset buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import './App.css'
 import TimerButton from './components/TimerButton'
+import ResetButton from './components/ResetButton';
 
 function App() {
   const [isRunning, setIsRunning] = useState<boolean>(false);
@@ -12,6 +13,7 @@ function App() {
   return (
      <>
        <TimerButton toggleStart={toggleStart} label='Start'/>
+       <ResetButton toggleReset={() => {}}/>
      </>
   )
 }

--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+type BaseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "danger" | "neutral";
+  size?: "sm" | "md" | "lg";
+  isLoading?: boolean;
+};
+
+export default function BaseButton({
+  children,
+  "aria-label": ariaLabel,
+  variant = "neutral",
+  size = "md",
+  type = "button",
+  disabled,
+  isLoading = false,
+  ...rest
+}: BaseButtonProps) {
+  const variantStyles: Record<typeof variant, string> = {
+    primary: "bg-primary-light dark:bg-primary-dark",
+    secondary: "bg-secondary-light dark:bg-secondary-dark",
+    danger: "bg-danger-light dark:bg-danger-dark",
+    neutral: "bg-neutral-light dark:bg-neutral-dark",
+  };
+
+  const sizeStyles = {
+    sm: "px-3 py-1 text-sm",
+    md: "px-6 py-3",
+    lg: "px-8 py-4 text-lg",
+  };
+
+  return (
+    <button
+      type={type}
+      aria-label={ariaLabel}      
+      disabled={disabled || isLoading}
+      className={`
+        w-full md:min-w-[120px] md:w-auto
+        text-white
+        border border-white rounded-lg
+        hover:scale-105 focus:scale-105
+        focus:outline-none focus:ring-2 focus:ring-blue-400
+        transition-transform duration-200
+        disabled:opacity-50 disabled:cursor-not-allowed
+        ${variantStyles[variant]}
+        ${sizeStyles[size]}
+      `}
+      {...rest}
+    >
+      {isLoading ? <span>Loading...</span> : children}
+    </button>
+  );
+}

--- a/src/components/ResetButton.test.tsx
+++ b/src/components/ResetButton.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ResetButton from "./ResetButton";
+
+test("renders Reset button to the screen", () => {
+  const handleClick = vi.fn();
+  render(<ResetButton toggleReset={handleClick} disabled={false}/>);
+
+  const startButton = screen.getByRole('button', {name: /reset/i});
+
+  expect(startButton).toBeInTheDocument();
+
+  fireEvent.click(startButton);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+
+  
+})

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -1,0 +1,22 @@
+import BaseButton from "./BaseButton";
+
+type ResetButtonProps = {
+  toggleReset: () => void;
+  disabled?: boolean;
+}
+
+export default function ResetButton({toggleReset, disabled} : ResetButtonProps) {
+
+  return (
+    <BaseButton    
+      aria-label="Reset the timer"
+      onClick={toggleReset}
+      variant="secondary"
+      disabled={disabled}
+
+    >
+      Reset
+    </BaseButton>
+  )
+  
+}

--- a/src/components/TimerButton.tsx
+++ b/src/components/TimerButton.tsx
@@ -1,3 +1,5 @@
+import BaseButton from "./BaseButton";
+
 type StartButtonProps = {
   toggleStart: () => void;
   label: "Start" | "Pause" | "Resume";
@@ -7,23 +9,14 @@ type StartButtonProps = {
 export default function StartButton({toggleStart, label} : StartButtonProps) {
 
   return (
-    <button 
-      type="button"
-      aria-pressed={label !== "Start"}
+    <BaseButton       
+      aria-pressed={label !== "Pause"}
       aria-label={`${label} the timer`}
+      variant="primary"
       onClick={toggleStart}
-      className="
-        w-full md:min-w-[120px] md:w-auto
-        px-6 py-3
-        text-white
-        border border-white rounded-lg 
-        bg-gray-400  hover:bg-gray-500 
-        hover:scale-105 focus:scale-105
-        focus:outline-none focus:ring-2 focus:ring-blue-400 
-        transition-transform duration-200"
-    >
+      >
       {label}
-    </button>
+    </BaseButton>
   )
   
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,28 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          light: '#3b82f6', // light mode blue
+          dark: '#2563eb',  // dark mode blue
+        },
+        secondary: {
+          light: '#22c55e',
+          dark: '#16a34a',
+        },
+        danger: {
+          light: '#ef4444',
+          dark: '#b91c1c',
+        },
+        neutral: {
+          light: '#9ca3af',
+          dark: '#6b7280',
+        },
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
Introduced a reusable `BaseButton` component with semantic color variants (primary, secondary, danger, neutral) tied to Tailwind’s theme. Updated `TimerButton` and `ResetButton` to use `BaseButton`. This ensures consistent styling and prepares the app for light/dark themes.

## Related Issue
Closes #14 

## Changes
- Added `BaseButton` with variant, size, disabled, and loading support
- Extended Tailwind config with semantic colors and dark mode
- Updated `TimerButton` to use `BaseButton` (primary)
- Added `ResetButton` using `BaseButton` (secondary)
- Refactored `App.tsx` to render updated buttons

## Testing
- [x] Added `ResetButton.test.tsx`
- [x] `npm test` passes locally
- [x] Manually verified buttons render correctly and respond to light/dark themes

## QA Steps
1. Start the dev server with `npm run dev`
2. Verify Start/Pause/Resume button renders with primary styles
3. Verify Reset button renders with secondary styles
4. Toggle dark mode (`document.documentElement.classList.toggle('dark')`) and confirm colors switch

## Checklist
- [x] PR title uses Conventional Commits (`feat(button): add BaseButton with semantic variants and update Timer/Reset buttons`)
- [x] Branch is up to date with `main` (rebased if needed)
- [x] No generated files committed (`dist/`, `node_modules/`)