### PR TITLE
feat(timer): add Reset button and timer utilities

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,71 @@
-import { render, screen } from "@testing-library/react";
-import App from "./App";
+import { screen } from "@testing-library/react";
+import { renderApp } from "./utils/testUtils";
+import { INITIAL_SECONDS } from "./config/timerConfig";
+import { convertSecondsToTime } from "./utils/time";
+import { waitForNextTick, clickButton } from "./utils/testUtils";
 
-test("renders Pomodoro heading", async () => {
-  render(<App />);
-  const startButton = await screen.findByRole("button", { name: /start/i });
+describe("Timer behaviour", () => {
+  test("renders Start Button", async () => {
+    renderApp();
+    const startButton = await screen.findByRole("button", { name: /start/i });
+    expect(startButton).toBeInTheDocument();
+  });
 
-  expect(startButton).toBeInTheDocument();
+  test("Clicking Start button starts the timer", async () => {
+    renderApp();
+
+    await clickButton(/start/i);
+
+    const expectedDisplay = convertSecondsToTime(INITIAL_SECONDS);
+    expect(screen.getByText(expectedDisplay)).toBeInTheDocument();
+
+    await waitForNextTick(); // wait ~1s for countdown
+
+    const decreasedDisplay = convertSecondsToTime(INITIAL_SECONDS - 1);
+    expect(screen.getByText(decreasedDisplay)).toBeInTheDocument();
+  });
+
+  test("renders Reset Button", async () => {
+    renderApp();
+    const resetButton = await screen.findByRole("button", { name: /reset/i });
+    expect(resetButton).toBeInTheDocument();
+  });
+
+  test("Clicking the Reset button resets the timer", async () => {
+    renderApp();
+    await clickButton(/start/i);
+    await screen.findByRole("button", { name: /reset/i });
+
+    await waitForNextTick();
+
+    // Timer should have decreased
+    const decreasedDisplay = convertSecondsToTime(INITIAL_SECONDS - 1);
+    expect(screen.getByText(decreasedDisplay)).toBeInTheDocument();
+
+    await clickButton(/reset/i);
+
+    // Timer should reset to initial
+    const resetDisplay = convertSecondsToTime(INITIAL_SECONDS);
+    expect(screen.getByText(resetDisplay)).toBeInTheDocument();
+  });
+
+  test("Reset is only available when timer has started", async () => {
+    renderApp();
+
+    const resetButton = await screen.findByRole("button", { name: /reset/i });
+
+    // Initially disabled
+    expect(resetButton).toBeDisabled();
+
+    await clickButton(/start/i);
+    await waitForNextTick();
+
+    // Enabled while running
+    expect(resetButton).not.toBeDisabled();
+
+    await clickButton(/reset/i);
+
+    // Disabled again after reset
+    expect(resetButton).toBeDisabled();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,59 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./App.css";
 import TimerButton from "./components/TimerButton";
 import ResetButton from "./components/ResetButton";
+import { convertSecondsToTime } from "./utils/time";
+import { getTimerLabel } from "./utils/labels";
+import { INITIAL_SECONDS } from "./config/timerConfig";
 
 function App() {
   const [isRunning, setIsRunning] = useState<boolean>(false);
+  const [timeRemaining, setTimeRemaining] = useState<number>(INITIAL_SECONDS); //25 minutes in seconds
+
+  useEffect(() => {
+    let intervalId: number | undefined;
+    if (isRunning && timeRemaining > 0) {
+      intervalId = window.setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 1) {
+            setIsRunning(false);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [isRunning, timeRemaining]);
 
   function toggleStart() {
-    setIsRunning(!isRunning);
+    if (timeRemaining === 0) {
+      setTimeRemaining(INITIAL_SECONDS);
+      setIsRunning(true);
+    } else {
+      setIsRunning(!isRunning);
+    }
   }
+
+  function handleReset() {
+    setIsRunning(false);
+    setTimeRemaining(INITIAL_SECONDS);
+  }
+
+  const label = getTimerLabel(isRunning, timeRemaining, INITIAL_SECONDS);
 
   return (
     <>
-      <TimerButton toggleStart={toggleStart} label="Start" />
-      <ResetButton toggleReset={() => {}} />
+      <p>{convertSecondsToTime(timeRemaining)}</p>
+      <TimerButton toggleStart={toggleStart} label={label} />
+      <ResetButton
+        toggleReset={handleReset}
+        disabled={timeRemaining === INITIAL_SECONDS}
+      />
     </>
   );
 }

--- a/src/components/TimerButton.tsx
+++ b/src/components/TimerButton.tsx
@@ -3,15 +3,21 @@ import BaseButton from "./BaseButton";
 type StartButtonProps = {
   toggleStart: () => void;
   label: "Start" | "Pause" | "Resume";
+  disabled?: boolean;
 };
 
-export default function StartButton({ toggleStart, label }: StartButtonProps) {
+export default function StartButton({
+  toggleStart,
+  label,
+  disabled,
+}: StartButtonProps) {
   return (
     <BaseButton
       aria-pressed={label !== "Pause"}
       aria-label={`${label} the timer`}
       variant="primary"
       onClick={toggleStart}
+      disabled={disabled}
     >
       {label}
     </BaseButton>

--- a/src/config/timerConfig.ts
+++ b/src/config/timerConfig.ts
@@ -1,0 +1,2 @@
+export const INITIAL_SECONDS = 1500; // 25 minutes
+export const BREAK_SECONDS = 300; // 5 minuets

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -1,0 +1,12 @@
+export function getTimerLabel(
+  isRunning: boolean,
+  timeRemaining: number,
+  initialSeconds: number,
+): "Start" | "Pause" | "Resume" {
+  if (timeRemaining === initialSeconds || timeRemaining === 0) {
+    return "Start";
+  } else if (isRunning && timeRemaining > 0) {
+    return "Pause";
+  }
+  return "Resume";
+}

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -1,0 +1,36 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { convertSecondsToTime } from "./time";
+import App from "../App";
+
+/**
+ * Waits for the next timer tick in real time (default 1 second + buffer).
+ */
+export async function waitForNextTick(seconds = 1, buffer = 0.1) {
+  await act(async () => {
+    await new Promise((resolve) =>
+      setTimeout(resolve, (seconds + buffer) * 1000),
+    );
+  });
+}
+
+/**
+ * Clicks a button by its accessible name (case-insensitive).
+ */
+export async function clickButton(name: RegExp) {
+  const button = await screen.findByRole("button", { name });
+  act(() => {
+    fireEvent.click(button);
+  });
+  return button;
+}
+
+/**
+ * Returns formatted text for easy assertions.
+ */
+export function getTimeText(seconds: number) {
+  return convertSecondsToTime(seconds);
+}
+
+export function renderApp() {
+  return render(<App />);
+}

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,16 @@
+import { tick, convertSecondsToTime } from "./time";
+
+describe("time utilities", () => {
+  test("tick decreases time but not below zero", () => {
+    expect(tick(1500)).toBe(1499);
+    expect(tick(1)).toBe(0);
+    expect(tick(0)).toBe(0);
+  });
+
+  test("convertSecondsToTime formats correctly", () => {
+    expect(convertSecondsToTime(0)).toBe("00:00");
+    expect(convertSecondsToTime(5)).toBe("00:05");
+    expect(convertSecondsToTime(60)).toBe("01:00");
+    expect(convertSecondsToTime(125)).toBe("02:05");
+  });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,13 @@
+export function convertSecondsToTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return (
+    minutes.toString().padStart(2, "0") +
+    ":" +
+    remainingSeconds.toString().padStart(2, "0")
+  );
+}
+
+export function tick(prev: number): number {
+  return Math.max(prev - 1, 0);
+}


### PR DESCRIPTION
## Summary
Added a Reset button to allow users to stop and reset the Pomodoro timer back to its initial state (25:00).
This also introduces timer utility functions and testing helpers for cleaner, more maintainable code.

## Related Issue
Closes #2 

## Changes
- [x] Added ResetButton component and integrated it into App.tsx
- [x] Implemented handleReset() logic to stop the timer and reset timeRemaining
- [x] Added config/timerConfig.ts for centralising initial timer values
- [x] Added utils/time.ts and utils/testUtils.tsx for reusable helper functions
- [x] Updated TimerButton.tsx and related tests for consistent label handling
- [x] Expanded App.test.tsx to include Reset button behaviour and edge cases

## Screenshots / Demo (optional)
N/A — logic and components verified through unit tests

## Testing
- [x] Added new unit tests for Reset functionality and button state
- [x] npm test passes locally
- [x] Manually verified Reset stops timer and restores display to 25:00

## QA Steps
1. Click Start — timer begins counting down
2. Click Reset — timer should stop immediately and display 25:00
3. Verify Reset is disabled before starting, enabled while running, and disabled again after reset

## Checklist

- [x] PR title uses Conventional Commits (feat(timer): add Reset button and timer utilities)
- [x] Branch is up to date with main
- [x] No generated files committed
- [x] Tests and documentation updated where needed